### PR TITLE
Add settings.xml to overwrite properties within the submodules maven …

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,31 @@
+image: maven:3.6.3-jdk-11
+
+variables:
+  GIT_SUBMODULE_STRATEGY: normal
+  MAVEN_CLI_OPTS: "-s ../settings.xml"
+
+cache:
+  paths:
+    - ~/.m2/repository
+
+stages:
+  - build
+  - deploy
+
+build_feature:
+  stage: build
+  script:
+    - cd hibernate-ogm
+    - mvn ${MAVEN_CLI_OPTS} clean install
+  except:
+    refs:
+      - master
+
+deploy_artifacts:
+  stage: deploy
+  script:
+    - cd hibernate-ogm
+    - mvn ${MAVEN_CLI_OPTS} clean install deploy
+  only:
+    refs:
+      - master

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,37 @@
+<settings xmlns="http://maven.apache.org/settings/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <servers>
+        <server>
+            <id>gitlab-maven</id>
+            <configuration>
+                <httpHeaders>
+                    <property>
+                        <name>Job-Token</name>
+                        <value>${env.CI_JOB_TOKEN}</value>
+                    </property>
+                </httpHeaders>
+            </configuration>
+        </server>
+    </servers>
+
+    <profiles>
+        <profile>
+            <id>gitlab-build</id>
+            <properties>
+                <jboss.releases.repo.id>gitlab-maven</jboss.releases.repo.id>
+                <jboss.releases.repo.url>https://gitlab.com/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven
+                </jboss.releases.repo.url>
+                <jboss.snapshots.repo.id>gitlab-maven</jboss.snapshots.repo.id>
+                <jboss.snapshots.repo.url>https://gitlab.com/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven
+                </jboss.snapshots.repo.url>
+            </properties>
+        </profile>
+    </profiles>
+
+    <activeProfiles>
+        <activeProfile>gitlab-build</activeProfile>
+    </activeProfiles>
+
+</settings>


### PR DESCRIPTION
…setup.

The properties in question define the behavior of the project's distribution management.

Variables used:
CI_PROJECT_ID: Gitlab project ID
CI_JOB_TOKEN: Authenticate with Gitlabs maven repository.

Add Gitlab CI configuration.
The configuration contains two stages.

Build: Executed on feature branches
Deploy: Executed on the master branch, only